### PR TITLE
remove deprication warnings

### DIFF
--- a/app/models/chrno_audit/audit_record.rb
+++ b/app/models/chrno_audit/audit_record.rb
@@ -4,7 +4,7 @@
 # Сущность "запись лога".
 #
 class ChrnoAudit::AuditRecord < ActiveRecord::Base
-  set_table_name "audit_log"
+  self.table_name = "audit_log"
 
   # Кто изменил?
   belongs_to :initiator, polymorphic: true

--- a/lib/chrno_audit/dirty_secret.rb
+++ b/lib/chrno_audit/dirty_secret.rb
@@ -11,16 +11,14 @@ module ChrnoAudit
       before_filter :store_audit_context
     end
 
-    module InstanceMethods
-      ##
-      # Сохраняет в Thread.current необходимые для аудита данные.
-      #
-      def store_audit_context
-        Thread.current[ :audit_context ] = {
-          :current_user => self.try( :current_user ),
-          :controller   => self # OMG! OMG!
-        }
-      end
+    ##
+    # Сохраняет в Thread.current необходимые для аудита данные.
+    #
+    def store_audit_context
+      Thread.current[ :audit_context ] = {
+        :current_user => self.try( :current_user ),
+        :controller   => self # OMG! OMG!
+      }
     end
   end
 end


### PR DESCRIPTION
Убираем этот варнинг
DEPRECATION WARNING: Calling set_table_name is deprecated. Please use `self.table_name = 'the_name'` instead.

и этот

DEPRECATION WARNING: The InstanceMethods module inside ActiveSupport::Concern will be no longer included automatically. Please define instance methods directly in ChrnoAudit::DirtySecret instead.
