### PR TITLE
Initialization order fixed

### DIFF
--- a/lib/chrno_audit.rb
+++ b/lib/chrno_audit.rb
@@ -12,7 +12,7 @@ module ChrnoAudit
   include ActiveSupport::Configurable
 
   class Engine < Rails::Engine
-    initializer "chrno_audit.initialize" do
+    initializer "chrno_audit.initialize", :before => :load_active_support do
       require "chrno_audit/action_controller_concern"
       require "chrno_audit/active_record_concern"
 


### PR DESCRIPTION
ChrnoAudit::Engine was initialized after ActiveSupport, so the hooks didn't seem to work.
With :before => :load_active_support they now work fine.
